### PR TITLE
fix domain/project name: don't use id use name!

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -106,6 +106,9 @@ if __name__ == '__main__':
     os_user_domain = config.get(
         'OS_USER_DOMAIN_NAME',
         os.getenv('OS_USER_DOMAIN_NAME'))
+    os_project_domain = config.get(
+        'OS_PROJECT_DOMAIN_NAME',
+        os.getenv('OS_PROJECT_DOMAIN_NAME'))
     os_region = config.get('OS_REGION_NAME', os.getenv('OS_REGION_NAME'))
     os_timeout = config.get(
         'TIMEOUT_SECONDS', int(
@@ -131,6 +134,7 @@ if __name__ == '__main__':
         os_tenant_name,
         os_username,
         os_user_domain,
+        os_project_domain,
         os_region,
         os_timeout,
         os_retries)

--- a/exporter/osclient.py
+++ b/exporter/osclient.py
@@ -81,7 +81,7 @@ class OSClient(object):
                     "password": {
                         "user": {
                             "name": self.username,
-                            "domain": {"id": self.user_domain},
+                            "domain": {"name": self.user_domain},
                             "password": self.password
                         }
                     }
@@ -89,7 +89,7 @@ class OSClient(object):
                 "scope": {
                     "project": {
                         "name": self.tenant_name,
-                        "domain": {"id": self.user_domain}
+                        "domain": {"name": self.user_domain}
                     }
                 }
             }

--- a/exporter/osclient.py
+++ b/exporter/osclient.py
@@ -44,6 +44,7 @@ class OSClient(object):
             tenant_name,
             username,
             user_domain,
+            project_domain,
             region,
             timeout,
             retries):
@@ -52,6 +53,7 @@ class OSClient(object):
         self.tenant_name = tenant_name
         self.username = username
         self.user_domain = user_domain
+        self.project_domain = project_domain
         self.region = region
         self.timeout = timeout
         self.retries = retries
@@ -89,7 +91,7 @@ class OSClient(object):
                 "scope": {
                     "project": {
                         "name": self.tenant_name,
-                        "domain": {"name": self.user_domain}
+                        "domain": {"name": self.project_domain}
                     }
                 }
             }


### PR DESCRIPTION
fixes for domain names:

The variables OS_USER_DOMAIN_NAME and OS_PROJECT_DOMAIN_NAME refer to the respective domain names.

The openstack exporter currently uses OS_USER_DOMAIN_NAME for both projects and users.
Also the variables are used for the id instead of the name.

This PR fixed those two bugs
