### PR TITLE
get new token if token is invalid

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -134,7 +134,7 @@ if __name__ == '__main__':
         os_region,
         os_timeout,
         os_retries)
-    oscache = OSCache(os_polling_interval, os_region)
+    oscache = OSCache(os_polling_interval, os_region, osclient)
     collectors.append(oscache)
 
     check_os_api = CheckOSApi(oscache, osclient)

--- a/exporter/oscache.py
+++ b/exporter/oscache.py
@@ -39,7 +39,7 @@ class ThreadSafeDict(dict):
 
 class OSCache(Thread):
 
-    def __init__(self, refresh_interval, region):
+    def __init__(self, refresh_interval, region, osclient):
         Thread.__init__(self)
         self.daemon = True
         self.duration = 0
@@ -47,6 +47,7 @@ class OSCache(Thread):
         self.cache = ThreadSafeDict()
         self.region = region
         self.osclients = []
+        self.osclient = osclient
 
     def cache_me(self, osclient):
         self.osclients.append(osclient)
@@ -81,4 +82,8 @@ class OSCache(Thread):
                          'Cache refresh duration in seconds.',
                          labels, registry=registry)
         duration.labels(*label_values).set(self.duration)
+        tokenRefresh = Gauge('openstack_exporter_token_refresh_count',
+                         'Number of times the keystone token needed to be refreshed.',
+                         labels, registry=registry)
+        tokenRefresh.labels(*label_values).set(self.osclient.get_token_refresh_counter())
         return generate_latest(registry)


### PR DESCRIPTION
Sometimes a token becomes invalid even though it hasn't expired yet.
Detect this and get a new token if necessary.
add new counter: openstack_exporter_token_refresh_count