### PR TITLE
Changed self.extra_config['cpu_ratio'] to self.cpu_overcommit_ratio 

### DIFF
--- a/exporter/hypervisor_stats.py
+++ b/exporter/hypervisor_stats.py
@@ -97,7 +97,7 @@ class HypervisorStats(OSBase):
             for agg in nova_aggregates.keys():
                 agg_hosts = nova_aggregates[agg]['hosts']
                 if host in agg_hosts:
-                    free = ((int(self.extra_config['cpu_ratio'] *
+                    free = ((int(self.cpu_overcommit_ratio *
                                  m_vcpus)) -
                             m_vcpus_used)
                     nova_aggregates[agg]['metrics']['free_vcpus'] += free


### PR DESCRIPTION
If aggregate hosts exists within cluster, the hypervisor.py file will fail with error:
ERROR:'HypervisorStats' object has no attribute 'extra_config'
ERROR:failed to get data for cache key hypervisor_stats
The patch that I am trying to push replaces that variable with another variable used in the code before it. After changing the variables the program collects the desired information.
